### PR TITLE
Fix interator routines when incrementing/decrementing.

### DIFF
--- a/include/smooth/detail/utils.hpp
+++ b/include/smooth/detail/utils.hpp
@@ -159,7 +159,7 @@ public:
       requires std::ranges::forward_range<R>
     {
       _Iterator tmp = *this;
-      ++this;
+      ++*this;
       return tmp;
     }
 
@@ -174,7 +174,7 @@ public:
       requires std::ranges::bidirectional_range<R>
     {
       auto tmp = *this;
-      --this;
+      --*this;
       return tmp;
     }
 
@@ -314,7 +314,7 @@ public:
       requires(std::ranges::forward_range<View> && ...)
     {
       _Iterator tmp = *this;
-      ++this;
+      ++*this;
       return tmp;
     }
 

--- a/include/smooth/detail/utils.hpp
+++ b/include/smooth/detail/utils.hpp
@@ -159,7 +159,7 @@ public:
       requires std::ranges::forward_range<R>
     {
       _Iterator tmp = *this;
-      ++*this;
+      operator++();
       return tmp;
     }
 
@@ -174,7 +174,7 @@ public:
       requires std::ranges::bidirectional_range<R>
     {
       auto tmp = *this;
-      --*this;
+      operator--();
       return tmp;
     }
 
@@ -314,7 +314,7 @@ public:
       requires(std::ranges::forward_range<View> && ...)
     {
       _Iterator tmp = *this;
-      ++*this;
+      operator++();
       return tmp;
     }
 


### PR DESCRIPTION
Fix interator routines when incrementing/decrementing.

They were incrementing/decrementing the pointer, not the value
the pointer pointed at. This code no longer builds with latest
clang.
