### PR TITLE
fix: cherry pick iterator increment fix from upstream pettni

### DIFF
--- a/include/smooth/detail/utils.hpp
+++ b/include/smooth/detail/utils.hpp
@@ -159,7 +159,7 @@ public:
       requires std::ranges::forward_range<R>
     {
       _Iterator tmp = *this;
-      ++this;
+      operator++();
       return tmp;
     }
 
@@ -174,7 +174,7 @@ public:
       requires std::ranges::bidirectional_range<R>
     {
       auto tmp = *this;
-      --this;
+      operator--();
       return tmp;
     }
 
@@ -314,7 +314,7 @@ public:
       requires(std::ranges::forward_range<View> && ...)
     {
       _Iterator tmp = *this;
-      ++this;
+      operator++();
       return tmp;
     }
 


### PR DESCRIPTION
- TBD requested PR https://github.com/thoroai/smooth/pull/2 as clang was throwing compilation errors when building the latest version of ark. 
- The correct and clean fix for that same issue was found in the original upstream repo https://github.com/pettni/smooth.git as https://github.com/pettni/smooth/commit/08c5d55bd6756526ea9d83fea4685e4ed6fc6186. That has been cherry picked here.